### PR TITLE
feat(handlers): add automatic cache invalidation for event args

### DIFF
--- a/src/core/EventProcessor.ts
+++ b/src/core/EventProcessor.ts
@@ -11,6 +11,7 @@ import type { CacheInvalidationService } from '../services/CacheInvalidationServ
 import type { MetadataService } from '../services/MetadataService.js';
 import type { Contracts } from '../services/Contracts.js';
 import { getTracer, getMeter } from '../telemetry.js';
+import { extractAccountIdsFromArgs } from '../utils/accountIdUtils.js';
 
 import type { EventDecoder } from './EventDecoder.js';
 
@@ -88,26 +89,7 @@ export class EventProcessor {
         }
 
         const context = this._buildHandlerContext(client);
-        const handler = this._decoder.resolveHandler(event.contractAddress, event.eventName);
-        const handlerEvent = this._toHandlerEvent(event);
-
-        logger.info('handler_executing', {
-          schema: this._schema,
-          chainId: this._chainId,
-          eventName: event.eventName,
-          handler: handler.name,
-          pointer: this._formatEventPointer(event),
-        });
-
-        await handler(handlerEvent, context);
-
-        logger.info('handler_completed', {
-          schema: this._schema,
-          chainId: this._chainId,
-          eventName: event.eventName,
-          handler: handler.name,
-          pointer: this._formatEventPointer(event),
-        });
+        await this._executeHandler(event, context);
 
         await this._eventsRepo.markEventProcessed(
           client,
@@ -167,6 +149,34 @@ export class EventProcessor {
       handler: handler.name,
       pointer: this._formatEventPointer(event),
     });
+
+    await this._invalidateCacheForEvent(handlerEvent, context);
+  }
+
+  /**
+   * Invalidates cache for AccountIds affected by an event.
+   * Combines auto-detected IDs from event args with handler-specified additional IDs.
+   */
+  private async _invalidateCacheForEvent(
+    event: HandlerEvent,
+    context: HandlerContext,
+  ): Promise<void> {
+    const argsAccountIds = extractAccountIdsFromArgs(event.args);
+    const allAccountIds = [...argsAccountIds, ...context.additionalAccountIdsToInvalidate];
+    const uniqueAccountIds = [...new Set(allAccountIds)];
+
+    if (uniqueAccountIds.length > 0) {
+      await this._cacheInvalidationService.invalidate(uniqueAccountIds, event.blockTimestamp);
+
+      logger.debug('cache_invalidated_for_event', {
+        schema: this._schema,
+        chainId: this._chainId,
+        eventName: event.eventName,
+        argsAccountIds,
+        additionalAccountIds: context.additionalAccountIdsToInvalidate,
+        totalUniqueAccountIds: uniqueAccountIds.length,
+      });
+    }
   }
 
   /**
@@ -182,6 +192,7 @@ export class EventProcessor {
       contracts: this._contracts,
       cacheInvalidationService: this._cacheInvalidationService,
       visibilityThresholdBlockNumber: this._visibilityThresholdBlockNumber,
+      additionalAccountIdsToInvalidate: [],
     };
   }
 
@@ -235,6 +246,7 @@ export class EventProcessor {
           const context = this._buildHandlerContext(client);
 
           for (const event of batch) {
+            context.additionalAccountIdsToInvalidate.length = 0; // Reset for each event.
             await this._executeHandler(event, context);
 
             await this._eventsRepo.markEventProcessed(

--- a/src/handlers/AccountMetadataEmitted/accountMetadataEmittedHandler.ts
+++ b/src/handlers/AccountMetadataEmitted/accountMetadataEmittedHandler.ts
@@ -126,10 +126,6 @@ export const accountMetadataEmittedHandler: EventHandler<AccountMetadataEmittedE
     return;
   }
 
-  await ctx.cacheInvalidationService.invalidate(
-    (await ctx.splitsRepo.getCurrentSplitReceiversBySender(accountIdStr)).map(
-      (sr) => sr.receiver_account_id,
-    ),
-    event.blockTimestamp,
-  );
+  const splitReceivers = await ctx.splitsRepo.getCurrentSplitReceiversBySender(accountIdStr);
+  ctx.additionalAccountIdsToInvalidate.push(...splitReceivers.map((sr) => sr.receiver_account_id));
 };

--- a/src/handlers/EventHandler.ts
+++ b/src/handlers/EventHandler.ts
@@ -46,4 +46,10 @@ export type HandlerContext = {
   readonly contracts: Contracts;
   readonly cacheInvalidationService: CacheInvalidationService;
   readonly visibilityThresholdBlockNumber: bigint;
+  /**
+   * Collector for additional AccountIds that handlers discover via DB lookups.
+   * EventProcessor will combine these with auto-detected IDs from event args.
+   * Handlers should push to this array to register additional cache invalidations.
+   */
+  additionalAccountIdsToInvalidate: string[];
 };

--- a/src/handlers/givenHandler.ts
+++ b/src/handlers/givenHandler.ts
@@ -19,7 +19,7 @@ type GivenEvent = HandlerEvent & {
 
 export const givenHandler: EventHandler<GivenEvent> = async (event, ctx) => {
   const { accountId, receiver, erc20, amt } = event.args;
-  const { client, schema, cacheInvalidationService } = ctx;
+  const { client, schema } = ctx;
 
   const givenEvent = givenEventSchema.parse({
     account_id: accountId.toString(),
@@ -38,11 +38,6 @@ export const givenHandler: EventHandler<GivenEvent> = async (event, ctx) => {
     data: givenEvent,
     conflictColumns: ['transaction_hash', 'log_index'],
   });
-
-  await cacheInvalidationService.invalidate(
-    [accountId.toString(), receiver.toString()],
-    event.blockTimestamp,
-  );
 
   logger.info('given_event_processed', {
     accountId: accountId.toString(),

--- a/src/handlers/ownerUpdatedHandler.ts
+++ b/src/handlers/ownerUpdatedHandler.ts
@@ -21,7 +21,7 @@ type OwnerUpdatedEvent = HandlerEvent & {
 
 export const ownerUpdatedHandler: EventHandler<OwnerUpdatedEvent> = async (event, ctx) => {
   const { accountId, owner } = event.args;
-  const { client, schema, contracts, cacheInvalidationService } = ctx;
+  const { client, schema, contracts, additionalAccountIdsToInvalidate } = ctx;
   const eventPointer = toEventPointer(event);
   const accountIdStr = accountId.toString();
   const ownerAccountIdStr = (await contracts.addressDriver.read.calcAccountId([owner])).toString();
@@ -109,8 +109,5 @@ export const ownerUpdatedHandler: EventHandler<OwnerUpdatedEvent> = async (event
     logger.warn('owner_updated_unsupported_account', { accountId: accountIdStr });
   }
 
-  await cacheInvalidationService.invalidate(
-    [accountIdStr, ownerAccountIdStr],
-    event.blockTimestamp,
-  );
+  additionalAccountIdsToInvalidate.push(ownerAccountIdStr);
 };

--- a/src/handlers/streamReceiverSeenHandler.ts
+++ b/src/handlers/streamReceiverSeenHandler.ts
@@ -19,7 +19,7 @@ type StreamReceiverSeen = HandlerEvent & {
 
 export const streamReceiverSeenHandler: EventHandler<StreamReceiverSeen> = async (event, ctx) => {
   const { receiversHash, accountId, config } = event.args;
-  const { cacheInvalidationService, splitsRepo, client, schema } = ctx;
+  const { splitsRepo, client, schema, additionalAccountIdsToInvalidate } = ctx;
 
   const streamReceiverSeenEvent = streamReceiverSeenEventSchema.parse({
     account_id: accountId.toString(),
@@ -44,10 +44,6 @@ export const streamReceiverSeenHandler: EventHandler<StreamReceiverSeen> = async
     receiversHash,
   });
 
-  const splits = await splitsRepo.getCurrentSplitReceiversByReceiversHash(receiversHash);
-
-  await cacheInvalidationService.invalidate(
-    splits.map((split) => split.id.toString()),
-    event.blockTimestamp,
-  );
+  const splitReceivers = await splitsRepo.getCurrentSplitReceiversByReceiversHash(receiversHash);
+  additionalAccountIdsToInvalidate.push(...splitReceivers.map((split) => split.id.toString()));
 };

--- a/src/handlers/transferHandler.ts
+++ b/src/handlers/transferHandler.ts
@@ -32,7 +32,7 @@ export const transferHandler: EventHandler<TransferEvent> = async (event, ctx) =
     pendingNftTransfersRepo,
     contracts,
     visibilityThresholdBlockNumber,
-    cacheInvalidationService,
+    additionalAccountIdsToInvalidate,
   } = ctx;
 
   const transferEvent = transferEventSchema.parse({
@@ -57,14 +57,8 @@ export const transferHandler: EventHandler<TransferEvent> = async (event, ctx) =
   const isMint = from === zeroAddress;
   const ownerAccountId = (await contracts.addressDriver.read.calcAccountId([to])).toString();
 
-  await cacheInvalidationService.invalidate(
-    [
-      accountId,
-      (await contracts.addressDriver.read.calcAccountId([from])).toString(),
-      ownerAccountId,
-    ],
-    event.blockTimestamp,
-  );
+  const fromAccountId = (await contracts.addressDriver.read.calcAccountId([from])).toString();
+  additionalAccountIdsToInvalidate.push(fromAccountId, ownerAccountId);
 
   const commonData = {
     owner_address: to,

--- a/src/utils/accountIdUtils.ts
+++ b/src/utils/accountIdUtils.ts
@@ -1,0 +1,63 @@
+import { isAddress } from 'viem';
+
+import { logger } from '../logger.js';
+
+import { getContractNameFromAccountId } from './getContractNameFromAccountId.js';
+
+/**
+ * Attempts to convert a value to a valid AccountId string.
+ * Returns null if the value cannot be converted (not a valid AccountId).
+ *
+ * This is a "try" variant that never throws - failures are silent.
+ * Used for automatic extraction from event args where not all values are AccountIds.
+ */
+export function tryConvertToAccountId(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  // Skip Ethereum addresses
+  if (typeof value === 'string' && isAddress(value)) {
+    return null;
+  }
+
+  // Convert to string representation
+  let idStr: string;
+  if (typeof value === 'bigint') {
+    idStr = value.toString();
+  } else if (typeof value === 'string') {
+    idStr = value;
+  } else if (typeof value === 'number') {
+    idStr = value.toString();
+  } else {
+    return null;
+  }
+
+  // Validate it belongs to a known driver
+  try {
+    getContractNameFromAccountId(idStr);
+    return idStr;
+  } catch (error) {
+    // Log unknown driver errors as they may indicate a new driver type not yet supported
+    if (error instanceof Error && error.message.includes('Unknown driver')) {
+      logger.warn('unrecognized_account_id_driver', { value: idStr });
+    }
+    return null;
+  }
+}
+
+/**
+ * Extracts all valid AccountIds from an event args object.
+ */
+export function extractAccountIdsFromArgs(args: Record<string, unknown>): string[] {
+  const accountIds = new Set<string>();
+
+  for (const value of Object.values(args)) {
+    const accountId = tryConvertToAccountId(value);
+    if (accountId !== null) {
+      accountIds.add(accountId);
+    }
+  }
+
+  return Array.from(accountIds);
+}


### PR DESCRIPTION
Implement automatic AccountId extraction from event args with centralized cache invalidation in EventProcessor.

- Add tryConvertToAccountId() and extractAccountIdsFromArgs() utilities
- Add additionalAccountIdsToInvalidate collector to HandlerContext
- Auto-invalidate detected AccountIds after each handler execution
- Migrate existing handlers to use context collector pattern
- Refactor processNext() to use _executeHandler() for consistency

Handlers now automatically invalidate cache for AccountIds in event args. Handlers needing calculated or DB-lookup IDs push to the context collector. This fixes splitHandler (and others) silently skipping cache invalidation.

Resolves: https://github.com/drips-network/dripfeed/issues/3