### PR TITLE
add support for lit-enabled protocol

### DIFF
--- a/src/chains/abis/repoDriverAbi.ts
+++ b/src/chains/abis/repoDriverAbi.ts
@@ -64,6 +64,16 @@ export const repoDriverAbi = [
     anonymous: false,
     inputs: [
       { indexed: true, internalType: 'uint256', name: 'accountId', type: 'uint256' },
+      { indexed: false, internalType: 'uint8', name: 'sourceId', type: 'uint8' },
+      { indexed: false, internalType: 'bytes', name: 'name', type: 'bytes' },
+    ],
+    name: 'AccountIdSeen',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'uint256', name: 'accountId', type: 'uint256' },
       { indexed: false, internalType: 'enum Forge', name: 'forge', type: 'uint8' },
       { indexed: false, internalType: 'bytes', name: 'name', type: 'bytes' },
       { indexed: false, internalType: 'address', name: 'payer', type: 'address' },

--- a/src/chains/chain-configs/sepolia.ts
+++ b/src/chains/chain-configs/sepolia.ts
@@ -3,15 +3,15 @@ import * as c from '../contractConfigFactories.js';
 
 export const sepoliaConfig = {
   chainId: 11155111,
-  startBlock: 4416384,
+  startBlock: 10140802,
   visibilityThresholdBlockNumber: 0,
   contracts: [
-    c.drips('0x74A32a38D945b9527524900429b083547DeB9bF4'),
-    c.nftDriver('0xdC773a04C0D6EFdb80E7dfF961B6a7B063a28B44'),
-    c.repoDriver('0xa71bdf410D48d4AA9aE1517A69D7E1Ef0c179b2B'),
-    c.addressDriver('0x70E1E1437AeFe8024B6780C94490662b45C3B567'),
-    c.repoDeadlineDriver('0x4e576318213e3c9b436d0758a021a485c5d8b929'),
-    c.repoSubAccountDriver('0x317400fd9dfdad78d53a34455d89beb8f03f90ee'),
-    c.immutableSplitsDriver('0xC3C1955bb50AdA4dC8a55aBC6d4d2a39242685c1'),
+    c.drips('0x2cd644bACE1926DeA14693c125F4751c9B25f661'),
+    c.nftDriver('0x07418488D535fed8E765e9Ca993611BceA79af00'),
+    c.repoDriver('0xE2111564E384d6D55D1Ce6e3dF5f2cfE24004DfA'),
+    c.addressDriver('0xB77F6Ed18E58d4f9d4986F23BcE40fcb9ce3B05a'),
+    c.repoDeadlineDriver('0x67672F910B9195F232beC4F4040a0F2d0218402c'),
+    c.repoSubAccountDriver('0xA3F066e41DF5c0037ED67dA0a546bC9382B46fD1'),
+    c.immutableSplitsDriver('0x8714cEFdd6e19f309dF4aEd3500994011cA9097C'),
   ],
 } as const as ChainConfig;

--- a/src/chains/monitoredEvents.ts
+++ b/src/chains/monitoredEvents.ts
@@ -10,7 +10,7 @@ export const DRIPS_EVENTS = [
 
 export const NFT_DRIVER_EVENTS = ['Transfer'];
 
-export const REPO_DRIVER_EVENTS = ['OwnerUpdateRequested', 'OwnerUpdated'];
+export const REPO_DRIVER_EVENTS = ['AccountIdSeen', 'OwnerUpdateRequested', 'OwnerUpdated'];
 
 export const ADDRESS_DRIVER_EVENTS: string[] = [];
 

--- a/src/handlers/accountIdSeenHandler.ts
+++ b/src/handlers/accountIdSeenHandler.ts
@@ -1,0 +1,86 @@
+import { fromHex, type DecodeEventLogReturnType } from 'viem';
+
+import type { RepoDriverAbi } from '../chains/abis/abiTypes.js';
+import { logger } from '../logger.js';
+import { mapForge, forgeToUrl } from '../utils/forgeUtils.js';
+import { isOrcidAccount, isProject } from '../utils/repoDriverAccountUtils.js';
+import { toEventPointer } from '../repositories/types.js';
+import { insertIgnore } from '../db/db.js';
+import {
+  projectSchema,
+  type Project,
+  type ProjectStatus,
+  linkedIdentitySchema,
+  type LinkedIdentity,
+  type LinkedIdentityType,
+} from '../db/schemas.js';
+
+import type { EventHandler, HandlerEvent } from './EventHandler.js';
+
+type AccountIdSeenEvent = HandlerEvent & {
+  args: DecodeEventLogReturnType<RepoDriverAbi, 'AccountIdSeen'>['args'];
+};
+
+export const accountIdSeenHandler: EventHandler<AccountIdSeenEvent> = async (event, ctx) => {
+  const { accountId, sourceId, name } = event.args;
+  const { client, schema } = ctx;
+  const eventPointer = toEventPointer(event);
+  const accountIdStr = accountId.toString();
+  const nameStr = fromHex(name, 'string');
+
+  if (isProject(accountIdStr)) {
+    const forgeValue = mapForge(Number(sourceId));
+    const { entity: project, created } = await insertIgnore<Project>({
+      client,
+      table: `${schema}.projects`,
+      data: {
+        account_id: accountIdStr,
+        forge: forgeValue,
+        name: nameStr,
+        url: forgeToUrl(forgeValue, nameStr),
+        owner_address: null,
+        owner_account_id: null,
+        verification_status: 'unclaimed' as ProjectStatus,
+        is_valid: true,
+        is_visible: true,
+        last_event_block: eventPointer.last_event_block,
+        last_event_tx_index: eventPointer.last_event_tx_index,
+        last_event_log_index: eventPointer.last_event_log_index,
+      },
+      conflictColumns: ['account_id'],
+      schema: projectSchema,
+    });
+
+    if (created) {
+      logger.info('account_id_seen_project_created', { project });
+    } else {
+      logger.info('account_id_seen_project_exists', { project });
+    }
+  } else if (isOrcidAccount(accountIdStr)) {
+    const { entity: linkedIdentity, created } = await insertIgnore<LinkedIdentity>({
+      client,
+      table: `${schema}.linked_identities`,
+      data: {
+        account_id: accountIdStr,
+        identity_type: 'orcid' as LinkedIdentityType,
+        owner_address: null,
+        owner_account_id: null,
+        are_splits_valid: false,
+        is_visible: true,
+        last_event_block: eventPointer.last_event_block,
+        last_event_tx_index: eventPointer.last_event_tx_index,
+        last_event_log_index: eventPointer.last_event_log_index,
+      },
+      conflictColumns: ['account_id'],
+      schema: linkedIdentitySchema,
+    });
+
+    if (created) {
+      logger.info('account_id_seen_linked_identity_created', { linkedIdentity });
+    } else {
+      logger.info('account_id_seen_linked_identity_exists', { linkedIdentity });
+    }
+  } else {
+    logger.warn('account_id_seen_unsupported_account', { accountId: accountIdStr });
+  }
+};

--- a/src/handlers/registry.ts
+++ b/src/handlers/registry.ts
@@ -1,3 +1,4 @@
+import { accountIdSeenHandler } from './accountIdSeenHandler.js';
 import { accountMetadataEmittedHandler } from './AccountMetadataEmitted/accountMetadataEmittedHandler.js';
 import type { EventHandler } from './EventHandler.js';
 import { givenHandler } from './givenHandler.js';
@@ -27,6 +28,7 @@ export const registry: Record<string, EventHandler> = {
   Transfer: transferHandler as EventHandler,
   SplitsSet: splitsSetHandler as EventHandler,
   StreamsSet: streamsSetHandler as EventHandler,
+  AccountIdSeen: accountIdSeenHandler as EventHandler,
   OwnerUpdated: ownerUpdatedHandler as EventHandler,
   SqueezedStreams: squeezedStreamsHandler as EventHandler,
   StreamReceiverSeen: streamReceiverSeenHandler as EventHandler,

--- a/src/utils/repoDriverAccountUtils.ts
+++ b/src/utils/repoDriverAccountUtils.ts
@@ -12,34 +12,37 @@ export function isRepoDriverId(id: string): boolean {
 }
 
 /**
- * Extracts the forge ID from a RepoDriver account ID.
+ * Extracts the source ID from a RepoDriver account ID.
+ *
+ * Account ID layout: `driverId (32 bits) | sourceId (7 bits) | isHash (1 bit) | nameEncoded (216 bits)`
+ *
+ * The 8 bits at positions 216-223 encode `sourceId (7 bits) | isHash (1 bit)`.
+ * We shift right by 1 to drop the isHash bit and get the pure sourceId.
  */
-function extractForgeFromAccountId(accountId: string) {
+function extractSourceIdFromAccountId(accountId: string): number {
   const accountIdAsBigInt = BigInt(accountId);
-  // Extract forgeId from bits 216-223 (8 bits after the 32-bit driver ID)
-  const forgeId = (accountIdAsBigInt >> 216n) & 0xffn;
-  return Number(forgeId);
+  const sourceIdAndHash = (accountIdAsBigInt >> 216n) & 0xffn;
+  return Number(sourceIdAndHash >> 1n);
 }
 
 /**
  * Checks if the given account ID represents an ORCID account.
  */
 export function isOrcidAccount(accountId: string): boolean {
-  // ForgeId for ORCID in account IDs. Value is 4 (not 2 like Forge.ORCID enum)
-  //because forgeId encodes both forge type and name length: 0,1=GitHub, 2,3=GitLab, 4=ORCID.
-  const ORCID_FORGE_ID = 4;
+  // Source IDs for ORCID: 2 = orcid, 4 = orcidSandbox
+  const ORCID_SOURCE_IDS = [2, 4];
 
-  return isRepoDriverId(accountId) && extractForgeFromAccountId(accountId) === ORCID_FORGE_ID;
+  return (
+    isRepoDriverId(accountId) && ORCID_SOURCE_IDS.includes(extractSourceIdFromAccountId(accountId))
+  );
 }
 
 /**
  * Checks if the given account ID represents a GitHub project.
  */
 export function isProject(accountId: string): boolean {
-  // ForgeId for GitHub in account IDs. Value is 0 or 1 depending on name length.
-  const GITHUB_FORGE_IDS = [0, 1];
+  // Source ID 0 = GitHub
+  const GITHUB_SOURCE_ID = 0;
 
-  return (
-    isRepoDriverId(accountId) && GITHUB_FORGE_IDS.includes(extractForgeFromAccountId(accountId))
-  );
+  return isRepoDriverId(accountId) && extractSourceIdFromAccountId(accountId) === GITHUB_SOURCE_ID;
 }


### PR DESCRIPTION
With the lit-based flow, we no longer get `requestUpdateOwner` events to initially populate project information from. Instead, we need to use the new `AccountIdSeen` event.

Open question:
- This _should_ be backwards compatible, in theory we can deploy it and it will just continue working once the mainnet protocol is upgraded. But we should verify.